### PR TITLE
テストスキーマ分離と統合テスト修正

### DIFF
--- a/src/test/kotlin/com/example/ec/integration/config/JooqTestConfig.kt
+++ b/src/test/kotlin/com/example/ec/integration/config/JooqTestConfig.kt
@@ -1,0 +1,15 @@
+package com.example.ec.integration.config
+
+import org.jooq.conf.Settings
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+
+/**
+ * テスト時は currentSchema=test に任せるため、スキーマ名を SQL に出力しない。
+ * （本番の DSLContext 設定には影響しないよう TestConfiguration として分離）
+ */
+@TestConfiguration
+class JooqTestConfig {
+    @Bean
+    fun jooqTestSettings(): Settings = Settings().withRenderSchema(false)
+}

--- a/src/test/resources/sql/order-detail-test-data.sql
+++ b/src/test/resources/sql/order-detail-test-data.sql
@@ -1,3 +1,5 @@
+SET search_path TO test;
+
 -- Insert test customer
 INSERT INTO customer (id, name, email, created_at) VALUES
     (1, 'Test Customer', 'test@example.com', '2024-01-01 10:00:00');

--- a/src/test/resources/sql/rollback.sql
+++ b/src/test/resources/sql/rollback.sql
@@ -1,3 +1,5 @@
+SET search_path TO test;
+
 DELETE FROM order_attribute_value;
 DELETE FROM order_item;
 DELETE FROM "order";


### PR DESCRIPTION
#10 テスト用スキーマを `test` に分離し、Orders API 統合テストを修正しました。

## 変更点
- IntegrationSpec で Testcontainers の JDBC URL に `currentSchema=test` を付与し、Flyway も `schemas/default-schema=test` + `create-schemas=true` に設定。
- テスト専用の jOOQ Settings(withRenderSchema(false)) を提供し、SQL に public スキーマを付けないようにして 500 を解消。
- テスト SQL フィクスチャに `SET search_path TO test;` を追加してスキーマ前提を統一。

## 動作確認
- `./gradlew test --tests com.example.ec.integration.OrdersApiIntegrationTest`

## 補足（未対応）
- Gradle タスク依存の都合でテスト実行時に `flywayMigrate` → `generateJooq` が毎回走る件は未着手（build.gradle.kts の dependsOn が原因）。別途最適化予定です。
