### PR TITLE
feat: implement GET /api/orders list endpoint (Phase 3 of Issue #2)

### DIFF
--- a/src/main/kotlin/com/example/ec/application/order/GetOrdersUseCase.kt
+++ b/src/main/kotlin/com/example/ec/application/order/GetOrdersUseCase.kt
@@ -1,0 +1,34 @@
+package com.example.ec.application.order
+
+import com.example.ec.domain.order.OrderRepository
+import com.example.ec.domain.shared.Page
+import org.springframework.stereotype.Service
+import java.time.LocalDateTime
+
+/**
+ * 注文一覧取得ユースケース
+ */
+@Service
+class GetOrdersUseCase(
+    private val orderRepository: OrderRepository
+) {
+    /**
+     * 注文一覧を検索する
+     *
+     * @param from 注文日の開始日時
+     * @param to 注文日の終了日時
+     * @param customerName 顧客名（部分一致）
+     * @param page ページ番号（0-indexed）
+     * @param size ページサイズ
+     * @return ページング結果
+     */
+    fun execute(
+        from: LocalDateTime?,
+        to: LocalDateTime?,
+        customerName: String?,
+        page: Int,
+        size: Int
+    ): Page<OrderListItemView> {
+        return orderRepository.searchForList(from, to, customerName, page, size)
+    }
+}

--- a/src/main/kotlin/com/example/ec/application/order/OrderListItemView.kt
+++ b/src/main/kotlin/com/example/ec/application/order/OrderListItemView.kt
@@ -1,0 +1,17 @@
+package com.example.ec.application.order
+
+import java.math.BigDecimal
+import java.time.LocalDateTime
+
+/**
+ * 注文一覧表示用のビューデータ
+ *
+ * N+1問題を避けるため、リポジトリ層で顧客名を含めて取得する
+ */
+data class OrderListItemView(
+    val id: Long,
+    val customerName: String,
+    val orderDate: LocalDateTime,
+    val totalAmount: BigDecimal,
+    val itemCount: Int
+)

--- a/src/main/kotlin/com/example/ec/domain/order/OrderRepository.kt
+++ b/src/main/kotlin/com/example/ec/domain/order/OrderRepository.kt
@@ -1,5 +1,6 @@
 package com.example.ec.domain.order
 
+import com.example.ec.application.order.OrderListItemView
 import com.example.ec.domain.shared.ID
 import com.example.ec.domain.shared.Page
 import java.time.LocalDateTime
@@ -33,6 +34,26 @@ interface OrderRepository {
         page: Int,
         size: Int
     ): Page<Order>
+
+    /**
+     * 注文一覧を検索する（顧客名を含む、ページング付き）
+     *
+     * N+1問題を避けるため、顧客情報を1つのクエリで取得する
+     *
+     * @param from 注文日の開始日時（inclusive、nullの場合は制限なし）
+     * @param to 注文日の終了日時（inclusive、nullの場合は制限なし）
+     * @param customerName 顧客名での部分一致検索（nullの場合は検索しない）
+     * @param page ページ番号（0-indexed）
+     * @param size ページサイズ
+     * @return ページング結果（注文一覧表示用のビューデータ）
+     */
+    fun searchForList(
+        from: LocalDateTime?,
+        to: LocalDateTime?,
+        customerName: String?,
+        page: Int,
+        size: Int
+    ): Page<OrderListItemView>
 
     /**
      * 全件数を取得する

--- a/src/main/kotlin/com/example/ec/presentation/controller/OrderListController.kt
+++ b/src/main/kotlin/com/example/ec/presentation/controller/OrderListController.kt
@@ -1,0 +1,69 @@
+package com.example.ec.presentation.controller
+
+import com.example.ec.application.order.GetOrdersUseCase
+import com.example.ec.application.order.OrderListItemView
+import com.example.ec.presentation.model.OrderListResponse
+import com.example.ec.presentation.model.PagedOrderListResponse
+import org.springframework.format.annotation.DateTimeFormat
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+
+/**
+ * 注文一覧取得コントローラ
+ *
+ * OpenAPI生成のOrdersApiインターフェースは仕様参照のみに使用し、
+ * Spring MVCのルーティングは自前で定義することで、
+ * APIごとにControllerを分割できる設計としている。
+ */
+@RestController
+@RequestMapping("/api/orders")
+class OrderListController(
+    private val getOrdersUseCase: GetOrdersUseCase
+) {
+
+    @GetMapping
+    fun getOrders(
+        @RequestParam(required = false)
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+        from: LocalDateTime?,
+        @RequestParam(required = false)
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+        to: LocalDateTime?,
+        @RequestParam(required = false)
+        customerName: String?,
+        @RequestParam(defaultValue = "0")
+        page: Int,
+        @RequestParam(defaultValue = "20")
+        size: Int
+    ): ResponseEntity<PagedOrderListResponse> {
+        val ordersPage = getOrdersUseCase.execute(from, to, customerName, page, size)
+
+        val response = PagedOrderListResponse(
+            content = ordersPage.content.map { it.toResponse() },
+            page = ordersPage.page,
+            propertySize = ordersPage.size,
+            totalPages = ordersPage.totalPages,
+            totalElements = ordersPage.totalElements
+        )
+
+        return ResponseEntity.ok(response)
+    }
+}
+
+/**
+ * OrderListItemView を OrderListResponse に変換する
+ */
+private fun OrderListItemView.toResponse(): OrderListResponse {
+    return OrderListResponse(
+        id = id,
+        customerName = customerName,
+        orderDate = orderDate.atOffset(ZoneOffset.UTC),
+        totalAmount = totalAmount.toDouble(),
+        itemCount = itemCount
+    )
+}

--- a/src/main/resources/openapi/api.yaml
+++ b/src/main/resources/openapi/api.yaml
@@ -196,33 +196,49 @@ paths:
     get:
       tags:
         - orders
-      summary: Get all orders
+      summary: Get orders with pagination and filtering
+      description: Get paginated list of orders with optional filtering by date range and customer name
       operationId: getOrders
       parameters:
-        - name: customerId
+        - name: from
           in: query
+          description: Filter orders from this date (ISO 8601 format)
           schema:
-            type: integer
-            format: int64
+            type: string
+            format: date-time
+        - name: to
+          in: query
+          description: Filter orders until this date (ISO 8601 format)
+          schema:
+            type: string
+            format: date-time
+        - name: customerName
+          in: query
+          description: Filter by customer name (partial match)
+          schema:
+            type: string
         - name: page
           in: query
+          description: Page number (0-indexed)
           schema:
             type: integer
             default: 0
+            minimum: 0
         - name: size
           in: query
+          description: Page size
           schema:
             type: integer
             default: 20
+            minimum: 1
+            maximum: 100
       responses:
         '200':
           description: Success
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/OrderResponse'
+                $ref: '#/components/schemas/PagedOrderListResponse'
     post:
       tags:
         - orders
@@ -318,6 +334,59 @@ components:
         createdAt:
           type: string
           format: date-time
+
+    # Order List API schemas
+    PagedOrderListResponse:
+      type: object
+      required:
+        - content
+        - page
+        - size
+        - totalPages
+        - totalElements
+      properties:
+        content:
+          type: array
+          items:
+            $ref: '#/components/schemas/OrderListResponse'
+        page:
+          type: integer
+          description: Current page number (0-indexed)
+        size:
+          type: integer
+          description: Page size
+        totalPages:
+          type: integer
+          description: Total number of pages
+        totalElements:
+          type: integer
+          format: int64
+          description: Total number of elements
+
+    OrderListResponse:
+      type: object
+      required:
+        - id
+        - customerName
+        - orderDate
+        - totalAmount
+        - itemCount
+      properties:
+        id:
+          type: integer
+          format: int64
+        customerName:
+          type: string
+          description: Customer name
+        orderDate:
+          type: string
+          format: date-time
+        totalAmount:
+          type: number
+          format: double
+        itemCount:
+          type: integer
+          description: Number of items in the order
 
     CustomerSummary:
       type: object

--- a/src/test/resources/sql/orders-list-test-data.sql
+++ b/src/test/resources/sql/orders-list-test-data.sql
@@ -1,0 +1,24 @@
+SET search_path TO test;
+
+-- Insert test customers
+INSERT INTO customer (id, name, email, created_at) VALUES
+    (1, 'Alice Smith', 'alice@example.com', '2024-01-01 10:00:00'),
+    (2, 'Bob Johnson', 'bob@example.com', '2024-01-02 10:00:00'),
+    (3, 'Charlie Brown', 'charlie@example.com', '2024-01-03 10:00:00');
+
+-- Insert test orders
+INSERT INTO "order" (id, customer_id, order_date, total_amount, created_at) VALUES
+    (1, 1, '2024-01-10 10:00:00', 1000.00, '2024-01-10 10:00:00'),
+    (2, 2, '2024-01-15 12:00:00', 2500.00, '2024-01-15 12:00:00'),
+    (3, 1, '2024-01-20 14:00:00', 500.00, '2024-01-20 14:00:00'),
+    (4, 3, '2024-01-25 16:00:00', 3000.00, '2024-01-25 16:00:00'),
+    (5, 2, '2024-02-01 10:00:00', 1500.00, '2024-02-01 10:00:00');
+
+-- Insert test order items
+INSERT INTO order_item (id, order_id, product_name, quantity, unit_price, created_at) VALUES
+    (1, 1, 'Product A', 2, 500.00, '2024-01-10 10:00:00'),
+    (2, 2, 'Product B', 1, 2500.00, '2024-01-15 12:00:00'),
+    (3, 3, 'Product C', 1, 500.00, '2024-01-20 14:00:00'),
+    (4, 4, 'Product D', 3, 1000.00, '2024-01-25 16:00:00'),
+    (5, 5, 'Product E', 1, 1500.00, '2024-02-01 10:00:00'),
+    (6, 5, 'Product F', 1, 0.00, '2024-02-01 10:00:00');


### PR DESCRIPTION
## 概要

Issue #2（Orders API実装）の **Phase 3: GET /api/orders 一覧取得** を実装しました。

## 実装内容

### 1. OpenAPI定義更新
- GET /api/orders エンドポイント定義を追加
  - クエリパラメータ: `from`, `to`, `customerName`, `page`, `size`
  - `PagedOrderListResponse` スキーマ追加（content, page, size, totalPages, totalElements）
  - `OrderListResponse` スキーマ追加（id, customerName, orderDate, totalAmount, itemCount）

### 2. Repository層
- `OrderRepository.searchForList()` メソッド追加
  - 顧客名を JOIN で取得
  - アイテム数をサブクエリで取得
  - **N+1問題を回避**: 1つのSQLクエリで必要なデータを全て取得
- `OrderRepository.search()` のN+1問題を修正
  - 以前: 各注文ごとに `fetchItems()` を呼び出し（N+1クエリ）
  - 修正後: 全OrderItemsを `WHERE order_id IN (...)` で一括取得してグルーピング
- `buildSearchCondition()` ヘルパーメソッド追加（コード重複削減）

### 3. Application層
- `OrderListItemView.kt` 追加（注文一覧表示用ビューデータ）
- `GetOrdersUseCase.kt` 追加（注文一覧取得ユースケース）

### 4. Presentation層
- `OrderListController.kt` 追加
  - GET /api/orders エンドポイントを実装
  - クエリパラメータのバインディング
  - Domain → Response への変換

### 5. 統合テスト
- `OrdersApiIntegrationTest.kt` に以下のテストケースを追加:
  - ✅ ページネーションの動作確認
  - ✅ 日付範囲フィルタリング（from/to）
  - ✅ 顧客名での部分一致検索
  - ✅ 空リストのケース

## N+1問題の解決

### searchForList() メソッド
```sql
-- 顧客名とアイテム数を1つのクエリで取得
SELECT 
  order.id, 
  customer.name, 
  order.order_date, 
  order.total_amount,
  (SELECT COUNT(*) FROM order_item WHERE order_id = order.id) as item_count
FROM order
JOIN customer ON order.customer_id = customer.id
WHERE ...
ORDER BY order.order_date DESC, order.id DESC
LIMIT ? OFFSET ?
```

### search() メソッド
```kotlin
// 修正前: N+1問題
val orders = orderRecords.map { record ->
    val items = fetchItems(record.id!!)  // ← 各注文ごとにクエリ
    convertToOrder(record, items)
}

// 修正後: バッチフェッチ
val orderIds = orderRecords.map { it.id!! }
val itemsByOrderId = dsl.selectFrom(ORDER_ITEM)
    .where(ORDER_ITEM.ORDER_ID.`in`(orderIds))  // ← 1つのクエリで全取得
    .fetch()
    .groupBy { it.orderId!! }
```

## Phase 3 完了条件

- [x] GET /api/orders が実装され、フィルタ・ページングが動作する
- [x] OpenAPI定義が更新されている
- [x] Repository実装が完了（N+1問題解決済み）
- [x] UseCase実装が完了
- [x] Controller実装が完了
- [x] 統合テストが実装されている
- [x] 手動テストで動作確認済み

## 動作確認

```bash
# ページネーション
curl "http://localhost:8080/api/orders?page=0&size=5"

# 日付範囲フィルタ
curl "http://localhost:8080/api/orders?from=2024-01-15T00:00:00&to=2024-01-31T23:59:59"

# 顧客名検索
curl "http://localhost:8080/api/orders?customerName=Alice"
```

## レスポンス例

```json
{
  "content": [
    {
      "id": 1,
      "customerName": "Test Customer",
      "orderDate": "2024-01-15T14:30:00Z",
      "totalAmount": 3500.0,
      "itemCount": 2
    }
  ],
  "page": 0,
  "size": 5,
  "totalPages": 1,
  "totalElements": 1
}
```

## 関連Issue

Closes #2 (Phase 3完了)

🤖 Generated with [Claude Code](https://claude.com/claude-code)